### PR TITLE
fix: remove turbopack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbo",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
Template such as `loading.tsx` and `error.tsx` are not properly handled with turbopack.
It might be too early to use it 😢 

See https://github.com/vercel/next.js/discussions/42322