### PR TITLE
Fix crucial download link pocketbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Build a basic note-taking app with Next.js 13 and Pocketbase.
 1. Create a new Next.js app:
 `npx create-next-app@latest --ts`
 
-2. Download Pocketbase from [pocketbase.io](pocketbase.io)
+2. Download Pocketbase from [pocketbase.io](http://pocketbase.io)
 3. Navigate to the unzipped directory
 `cd pocketbase_0.7.9_darwin_arm64`
 4. Start Pocketbase:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Build a basic note-taking app with Next.js 13 and Pocketbase.
 1. Create a new Next.js app:
 `npx create-next-app@latest --ts`
 
-2. Download Pocketbase from [pocketbase.io](http://pocketbase.io)
+2. Download Pocketbase from [pocketbase.io](https://pocketbase.io/docs)
 3. Navigate to the unzipped directory
 `cd pocketbase_0.7.9_darwin_arm64`
 4. Start Pocketbase:


### PR DESCRIPTION
At university some Fireship io fans and I (colleagues) tried to download pocketbase, but without success.

We tried to follow the guide, but we encounter an error on link: pocketbase.io, so with this PR we want to encourage new devs to implement with one click access "pocketbase" site to download, and allow other devs to implement as fast as they can the tool, We think this is an amazing and beautiful tool, and if a team of 6 devs are frustrated to did accomplish using it! We want to add this way, to easy, fast and secure implement 1 command go to site to download pocketbase on their machines! Thanks to all team to make projects like this!